### PR TITLE
Added new gem to fix failing tests for board_spec.rb

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,1 +1,2 @@
+require 'rspec/collection_matchers'
 require_relative "../lib/tic_tac_toe.rb"

--- a/tic_tac_toe.gemspec
+++ b/tic_tac_toe.gemspec
@@ -22,4 +22,5 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
+  spec.add_development_dependency "rspec-collection_matchers"
 end


### PR DESCRIPTION
Updated to add rspec-collection_matchers gem as the "have" family of matchers was moved to this separate gem in rspec 3.0

This change to the rspec gem meant that the tests using "have" in spec/board_spec.rb were failing with NoMethodError. They now pass, though I can see some other failures - I will try to work through those separately.

This is my first pull request - apologies if I've missed anything out/got it wrong. Thanks for creating this tutorial, I'm enjoying working through it!
