### PR TITLE
Convert specs to RSpec 2.99.2 syntax with Transpec

### DIFF
--- a/spec/board_spec.rb
+++ b/spec/board_spec.rb
@@ -10,13 +10,13 @@ module TicTacToe
 
       it "sets the grid with three rows by default" do
         board = Board.new
-        expect(board.grid).to have(3).things
+        expect(board.grid.size).to eq(3)
       end
 
       it "creates three things in each row by default" do
         board = Board.new
         board.grid.each do |row|
-          expect(row).to have(3).things
+          expect(row.size).to eq(3)
         end
       end
     end
@@ -54,22 +54,22 @@ let(:empty) { TestCell.new }
 context "#game_over" do
   it "returns :winner if winner? is true" do
     board = Board.new
-    board.stub(:winner?) { true }
+    allow(board).to receive(:winner?) { true }
     expect(board.game_over).to eq :winner
   end
 
   it "returns :draw if winner? is false and draw? is true" do
     board = Board.new
-    board.stub(:winner?) { false }
-    board.stub(:draw?) { true }
+    allow(board).to receive(:winner?) { false }
+    allow(board).to receive(:draw?) { true }
     expect(board.game_over).to eq :draw
   end
 
   it "returns false if winner? is false and draw? is false" do
     board = Board.new
-    board.stub(:winner?) { false }
-    board.stub(:draw?) { false }
-    expect(board.game_over).to be_false
+    allow(board).to receive(:winner?) { false }
+    allow(board).to receive(:draw?) { false }
+    expect(board.game_over).to be_falsey
   end
 
   it "returns :winner when row has objects with values that are all the same" do
@@ -119,7 +119,7 @@ context "#game_over" do
       [y_cell, empty, empty]
     ]
     board = Board.new(grid: grid)
-    expect(board.game_over).to be_false
+    expect(board.game_over).to be_falsey
   end
 end
 

--- a/spec/core_extensions_spec.rb
+++ b/spec/core_extensions_spec.rb
@@ -3,29 +3,29 @@ require "spec_helper"
 describe Array do
   context "#all_empty?" do
     it "returns true if all elements of the Array are empty" do
-      expect(["", "", ""].all_empty?).to be_true
+      expect(["", "", ""].all_empty?).to be_truthy
     end
 
     it "returns false if some of the Array elements are not empty" do
-      expect(["", 1, "", Object.new, :a].all_empty?).to be_false
+      expect(["", 1, "", Object.new, :a].all_empty?).to be_falsey
     end
 
     it "returns true for an empty Array" do
-      expect([].all_empty?).to be_true
+      expect([].all_empty?).to be_truthy
     end
   end
 
   context "#all_same?" do
     it "returns true if all elements of the Array are the same" do
-      expect(["A", "A", "A"].all_same?).to be_true
+      expect(["A", "A", "A"].all_same?).to be_truthy
     end
 
     it "returns false if some of the Array elements are not the same" do
-      expect(["", 1, "", Object.new, :a].all_same?).to be_false
+      expect(["", 1, "", Object.new, :a].all_same?).to be_falsey
     end
 
     it "returns true for an empty Array" do
-      expect([].all_same?).to be_true
+      expect([].all_same?).to be_truthy
     end
   end
 

--- a/spec/game_spec.rb
+++ b/spec/game_spec.rb
@@ -9,13 +9,13 @@ module TicTacToe
 
     context "#initialize" do
       it "randomly selects a current_player" do
-        Array.any_instance.stub(:shuffle) { [frank, bob] }
+        allow_any_instance_of(Array).to receive(:shuffle) { [frank, bob] }
         game = Game.new([bob, frank])
         expect(game.current_player).to eq frank
       end
 
       it "randomly selects an other player" do
-        Array.any_instance.stub(:shuffle) { [frank, bob] }
+        allow_any_instance_of(Array).to receive(:shuffle) { [frank, bob] }
         game = Game.new([bob, frank])
         expect(game.other_player).to eq bob
       end
@@ -40,7 +40,7 @@ module TicTacToe
     context "#solicit_move" do
       it "asks the player to make a move" do
         game = Game.new([bob, frank])
-        game.stub(:current_player) { bob }
+        allow(game).to receive(:current_player) { bob }
         expected = "bob: Enter a number between 1 and 9 to make your move"
         expect(game.solicit_move).to eq expected
       end
@@ -61,15 +61,15 @@ module TicTacToe
     context "#game_over_message" do
       it "returns '{current player name} won!' if board shows a winner" do
         game = Game.new([bob, frank])
-        game.stub(:current_player) { bob }
-        game.board.stub(:game_over) { :winner }
+        allow(game).to receive(:current_player) { bob }
+        allow(game.board).to receive(:game_over) { :winner }
         expect(game.game_over_message).to eq "bob won!"
       end
 
       it "returns 'The game ended in a tie' if board shows a draw" do
         game = Game.new([bob, frank])
-        game.stub(:current_player) { bob }
-        game.board.stub(:game_over) { :draw }
+        allow(game).to receive(:current_player) { bob }
+        allow(game.board).to receive(:game_over) { :draw }
         expect(game.game_over_message).to eq "The game ended in a tie"
       end
     end


### PR DESCRIPTION
Please ignore previous pull request from me - I've since discovered that what I should have done was to use transpec to upgrade to Rspec 3.0.0!  Details below for the changes I made using transpec. All tests now pass with both rspec 2.99.2 and rspec 3.0.0, with no deprecation warnings.

This conversion is done by Transpec 2.3.6 with the following command:
    transpec
- 10 conversions
  from: obj.stub(:message)
    to: allow(obj).to receive(:message)
- 4 conversions
  from: be_false
    to: be_falsey
- 4 conversions
  from: be_true
    to: be_truthy
- 2 conversions
  from: Klass.any_instance.stub(:message)
    to: allow_any_instance_of(Klass).to receive(:message)
- 2 conversions
  from: expect(collection).to have(n).items
    to: expect(collection.size).to eq(n)

For more details: https://github.com/yujinakayama/transpec#supported-conversions
