### PR TITLE
update all instances of describe to the non-monkey patched RSpec.describe

### DIFF
--- a/spec/board_spec.rb
+++ b/spec/board_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 module TicTacToe
-  describe Board do
+  RSpec.describe Board do
 
     context "#initialize" do
       it "initializes the board with a grid" do
@@ -128,7 +128,7 @@ end
 
 
 #module TicTacToe
-  #describe Board do
+  #RSpec.describe Board do
 
     #context "#initialize" do
       #it "initializes the board with a grid" do

--- a/spec/cell_spec.rb
+++ b/spec/cell_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 module TicTacToe
-  describe Cell do
+  RSpec.describe Cell do
 
     context "#initialize" do
       it "is initialized with a value of '' by default" do

--- a/spec/core_extensions_spec.rb
+++ b/spec/core_extensions_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-describe Array do
+RSpec.describe Array do
   context "#all_empty?" do
     it "returns true if all elements of the Array are empty" do
       expect(["", "", ""].all_empty?).to be_truthy

--- a/spec/game_spec.rb
+++ b/spec/game_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 module TicTacToe
-  describe Game do
+  RSpec.describe Game do
 
     let (:bob) { Player.new({color: "X", name: "bob"}) }
     let (:frank) { Player.new({color: "O", name: "frank"}) }

--- a/spec/player_spec.rb
+++ b/spec/player_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 module TicTacToe
-  describe Player do
+  RSpec.describe Player do
 
     context "#initialize" do
       it "raises an exception when initialized with {}" do

--- a/wordpress_blog_post.txt
+++ b/wordpress_blog_post.txt
@@ -81,7 +81,7 @@ Create a spec/cell_spec.rb file that requires the spec_helper and is setup so te
 require "spec_helper"
 
 module TicTacToe
-  describe Cell do
+  RSpec.describe Cell do
     # tests will be added here
   end
 end
@@ -96,7 +96,7 @@ Start by testing that a Cell object that is instantiated with no arguments will 
 [code language="ruby"]
 # spec/cell_spec.rb
 module TicTacToe
-  describe Cell do
+  RSpec.describe Cell do
 
     context "#initialize" do
       it "is initialized with a value of '' by default" do
@@ -157,7 +157,7 @@ Test that the Player class will raise an exception when initialized with an inva
 require "spec_helper"
 
 module TicTacToe
-  describe Player do
+  RSpec.describe Player do
     context "#initialize" do
 
       it "raises an exception when initialized with {}" do
@@ -239,7 +239,7 @@ Add a test to make sure a Board can be instantiated with an input hash that has 
 require "spec_helper"
 
 module TicTacToe
-  describe Board do
+  RSpec.describe Board do
 
     context "#initialize" do
       it "initializes the board with a grid" do
@@ -408,7 +408,7 @@ Add a core_extensions_spec.rb file to test the behavior of the Array#all_empty? 
 [code language="ruby"]
 require "spec_helper"
 
-describe Array do
+RSpec.describe Array do
   context "#all_empty?" do
     it "returns true if all elements of the Array are empty" do
       expect(["", "", ""].all_empty?).to be_true
@@ -632,7 +632,7 @@ Add tests to make sure the @current_player and @other_player instance variables 
 [code language="ruby"]
 # spec/tic_tac_toe/game_spec.rb
 module TicTacToe
-  describe Game do
+  RSpec.describe Game do
 
     let (:bob) { Player.new({color: "X", name: "bob"}) }
     let (:frank) { Player.new({color: "O", name: "frank"}) }


### PR DESCRIPTION
Thanks for the encouragement @MrPowers !

I found it interesting your tests still ran successfully using just `describe`, but am moving forward with the update because of [this](https://github.com/rspec/rspec-rails/commit/ca0d249858903949052e06884e8e7f9d596cdc79)

I found a few things that I'd like to contribute. This project helped me immensely, so thanks for writing it!

